### PR TITLE
(PE-35977) Resolve URI compliance issues in jetty10 service

### DIFF
--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty10_service_handlers_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty10_service_handlers_test.clj
@@ -360,7 +360,9 @@
                                        :target-path "/ernie"}
                                       {:type :proxy :target-host "localhost" :target-port 10000
                                        :target-path "/kermit"}]
-                              "/quux" [{:type :websocket}]})))))))
+                              ;; websocket code currently disabled
+                              ;;"/quux" [{:type :websocket}]
+                              })))))))
 
   (testing "Log endpoints"
     (with-test-logging


### PR DESCRIPTION
Sets URI compliance of Jetty 10 to legacy mode to be compatible with the URLs we send with Puppet Server. Fixes jetty10-service-handlers-test.

See https://stackoverflow.com/questions/74395500/jetty-returns-400-when-uri-has-2-slashes-in-a-row-while-tomcat-doesnt-care for info about the new URI compliance in Jetty 10.