### PR TITLE
(PE-35979)  fix proxy test issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,9 +496,6 @@ route:
   to add additional headers) before Jetty continues on with the proxy. The
   function must accept two arguments, `[proxy-req req]`. For more information,
   see [below](#callback-fn).
-* `:failure-callback-fn`: optional; a function to manipulate the response object in case of failure.
-  The function must accept four arguments, `[req resp proxy-resp failure]`. For more information,
-  see [below](#failure-callback-fn).
 * `:request-buffer-size`: optional; an integer value to which to set the size
   of the request buffer used by the HTTP Client. This allows HTTP requests with
   very large cookies to go through, as a large cookie can cause the request
@@ -628,36 +625,6 @@ addition, a header `"x-example"` with the value `"baz"` will be added to the
 request before it is proxied, using the
 [`header`](http://download.eclipse.org/jetty/stable-9/apidocs/org/eclipse/jetty/client/api/Request.html#header%28java.lang.String,%20java.lang.String%29)
 method.
-
-#####`:failure-callback-fn`
-
-This option lets you provide a function to manipulate the response object in case of failure. It must take
-four arguments, `[req resp proxy-resp failure]`, where `req` is the original
-[`HttpServletRequest`](http://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletRequest.html),
-`resp` is an [`HttpServletResponse`](http://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletResponse.html),
-`proxy-req` a [`Response`](http://download.eclipse.org/jetty/stable-9/apidocs/org/eclipse/jetty/client/api/Response.html)
-and `failure` is a [`Throwable`](http://docs.oracle.com/javase/7/docs/api/java/lang/Throwable.html) explaining the
-cause of the problem.
-`resp` may be modified, the function does not return any value.
-
-An example with an on-failure function:
-
-```clj
-(defservice foo-service
-  [[:WebserverService add-proxy-route]]
-  (init [this context]
-    (add-proxy-route
-        {:host "localhost"
-         :port 10000
-         :path "/bar"}
-        "/foo"
-        {:failure-callback-fn (fn [req resp proxy-resp failure]
-          (.println (.getWriter resp) (str "Proxying failed: " (.getMessage failure))))})
-    context))
-```
-
-In this example, in case of proxying failure the response body will be augmented by an error message explaining
-what the cause of the problem was.
 
 #### `override-webserver-settings!`
 

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty10_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty10_config.clj
@@ -194,6 +194,7 @@
 
 (def WebserverClientSslContextFactory
   (dissoc WebserverSslContextFactory :client-auth))
+
 (def WebserverSslConnector
   (merge
     WebserverConnector

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty10_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty10_config.clj
@@ -192,6 +192,8 @@
    :protocols                          (schema/maybe [schema/Str])
    (schema/optional-key :allow-renegotiation)     (schema/maybe schema/Bool)})
 
+(def WebserverClientSslContextFactory
+  (dissoc WebserverSslContextFactory :client-auth))
 (def WebserverSslConnector
   (merge
     WebserverConnector

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty10_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty10_service.clj
@@ -58,7 +58,7 @@
                                                     second
                                                     :state
                                                     deref
-                                                    :ssl-context-factory)]
+                                                    :ssl-context-server-factory)]
                    (core/reload-crl-on-change! ssl-context-factory watcher)))
                (assoc started-context :watcher watcher))
              started-context)))

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty10_core_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty10_core_test.clj
@@ -164,7 +164,8 @@
                        :overrides-read-by-webserver false
                        :overrides nil
                        :endpoints {}
-                       :ssl-context-factory nil}
+                       :ssl-context-client-factory nil
+                       :ssl-context-server-factory nil}
         webserver-context (fn [state]
                             {:handlers (ContextHandlerCollection.)
                              :server nil


### PR DESCRIPTION
This updates the proxy handling to work correctly with jetty 10.

The `SslContextFactory$Server` in jetty 9 could be used for both server and client configuration.  In Jetty 10, there is a separate class specifically for client configuraton that must be used.  This updates the interfaces to configure both a server and client factory at setup time to allow the client to correctly use the ssl-configuraton with the requests that it is proxying.

The `failure-callback` behavior isn't simple nor straightforward as failure modes in jetty have changed.  For example, the tests that were checking the failure-callback are now generating an "IllegalArgumentException" that prevents the normal error handling routines from being used. Since this functionality isn't being used in any Puppet products, it is being removed.