### PR TITLE
(PE-35986) set shutdown timer default

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -72,29 +72,28 @@
                                             "test/java"]
                         :resource-paths ["dev-resources"]
                         :jvm-opts ["-Djava.util.logging.config.file=dev-resources/logging.properties"]}
-
+             :pseudo-dev [:defaults
+                          {:dependencies [[puppetlabs/http-client]
+                                          [puppetlabs/kitchensink nil :classifier "test"]
+                                          [puppetlabs/trapperkeeper nil :classifier "test"]
+                                          [org.clojure/tools.namespace]
+                                          [compojure]
+                                          [ring/ring-core]
+                                          [ch.qos.logback/logback-classic "1.2.12"]
+                                          [ch.qos.logback/logback-core "1.2.12"]
+                                          [ch.qos.logback/logback-access "1.2.12"]]}]
              :dev [:defaults
-                   {:dependencies [[org.bouncycastle/bcpkix-jdk18on]
-                                   [puppetlabs/http-client]
-                                   [puppetlabs/kitchensink nil :classifier "test"]
-                                   [puppetlabs/trapperkeeper nil :classifier "test"]
-                                   [org.clojure/tools.namespace]
-                                   [compojure]
-                                   [ring/ring-core]
-                                   [ch.qos.logback/logback-classic "1.2.12"]
-                                   [ch.qos.logback/logback-core "1.2.12"]
-                                   [ch.qos.logback/logback-access "1.2.12"]]}]
-
+                   :pseudo-dev
+                   {:dependencies [[org.bouncycastle/bcpkix-jdk18on]]}]
 
              ;; per https://github.com/technomancy/leiningen/issues/1907
              ;; the provided profile is necessary for lein jar / lein install
              :provided {:dependencies [[org.bouncycastle/bcpkix-jdk18on]]
                         :resource-paths ["dev-resources"]}
 
-             :fips [:defaults ; merge in the default profile
-                    {:dependencies [[org.bouncycastle/bcpkix-fips]
-                                    [org.bouncycastle/bc-fips]
-                                    [org.bouncycastle/bctls-fips]]
+             :fips {:dependencies [[org.bouncycastle/bcpkix-fips]
+                                   [org.bouncycastle/bc-fips]
+                                   [org.bouncycastle/bctls-fips]]
                      :exclusions [[org.bouncycastle/bcpkix-jdk18on]]
                      ;; this only ensures that we run with the proper profiles
                      ;; during testing. This JVM opt will be set in the puppet module
@@ -107,7 +106,7 @@
                                   (condp = (java.lang.Integer/parseInt major)
                                     11 ["-Djava.security.properties==dev-resources/jdk11-fips-security"]
                                     17 ["-Djava.security.properties==dev-resources/jdk17-fips-security"]
-                                    (throw unsupported-ex)))}]
+                                    (throw unsupported-ex)))}
 
              :testutils {:source-paths ^:replace ["test/clj"]
                          :java-source-paths ^:replace ["test/java"]}}

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty10_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty10_config.clj
@@ -91,6 +91,13 @@
 ;;; leaving them on by default.
 (def default-jmx-enable "true")
 
+;;;
+;;; Timeouts
+;;;
+;;; The stop timeout is the graceful shutdown period beteween when a server is asked to stop and when
+;; any open connections are closed.  This default came from Jetty 9.4, which changed to 0 in Jetty 10
+(def default-shutdown-timeout-seconds 30)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Schemas
 

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty10_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty10_core.clj
@@ -731,8 +731,7 @@
         ^HandlerCollection hc (HandlerCollection.)
          log-handler (config/maybe-init-log-handler options)]
     (.setHandlers hc (into-array Handler [(:handlers webserver-context)]))
-    (let [shutdown-timeout (when (not (nil? (:shutdown-timeout-seconds options)))
-                             (* 1000 (:shutdown-timeout-seconds options)))
+    (let [shutdown-timeout (* 1000 (:shutdown-timeout-seconds options config/default-shutdown-timeout-seconds))
           maybe-zipped (if (:gzip-enable options true)
                          (gzip-handler hc)
                          hc)
@@ -751,6 +750,7 @@
                                maybe-logged)]
       (.setHandler s statistics-handler)
       (when shutdown-timeout
+        (log/info (i18n/trs "Server shutdown timeout set to {0} milliseconds" shutdown-timeout))
         (.setStopTimeout s shutdown-timeout))
       (when-let [script (:post-config-script options)]
         (config/execute-post-config-script! s script))

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty10_default_config_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty10_default_config_test.clj
@@ -138,8 +138,8 @@ react accordingly."
 
 (deftest default-server-settings-test
   (let [server (Server.)]
-    ;; See: https://github.com/eclipse/jetty.project/blob/jetty-9.4.1.v20170120/jetty-util/src/main/java/org/eclipse/jetty/util/component/AbstractLifeCycle.java#L48
-    (is (= 30000 (.getStopTimeout server))
+    ;; See: https://github.com/eclipse/jetty.project/blob/jetty-10.0.15/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java#L183-L186
+    (is (= 0 (.getStopTimeout server))
         "Unexpected default for 'shutdown-timeout-seconds'")
     ;; See: https://github.com/eclipse/jetty.project/blob/jetty-9.4.1.v20170120/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java#L71
     (is (= 200 (get-max-threads-for-server server))


### PR DESCRIPTION
With jetty 10, the default shutdown timer for Server was changed from 30 seconds to 0, meaning that shutdown happens immediately. This caused various shutdown tests to fail. In order to maintain parity, this alters the default shutdown period from 0, to 30 seconds.