### PR TITLE
(maint) shift to com.puppetlabs publishing namespace

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def jetty-version "10.0.15")
 
-(defproject puppetlabs/trapperkeeper-webserver-jetty10 "1.0.1-SNAPSHOT"
+(defproject com.puppetlabs/trapperkeeper-webserver-jetty10 "1.0.0-SNAPSHOT"
   :description "A jetty10-based webserver implementation for use with the puppetlabs/trapperkeeper service framework."
   :url "https://github.com/puppetlabs/trapperkeeper-webserver-jetty10"
   :license {:name "Apache License, Version 2.0"


### PR DESCRIPTION
Move the project to com.puppetlabs to correspond to the new clojars naming requirements.