### PR TITLE
(maint) Make ring handler a ServletContextHandler, fixing broken call to getRequestCharacterEncoding

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty10_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty10_core.clj
@@ -32,6 +32,7 @@
            (org.eclipse.jetty.server AbstractConnectionFactory ConnectionFactory Handler HttpConfiguration
                                      HttpConnectionFactory Request
                                      Server ServerConnector SymlinkAllowedResourceAliasChecker)
+           (org.eclipse.jetty.server.session SessionHandler)
            (org.eclipse.jetty.server.handler AbstractHandler ContextHandler
                                              ContextHandlerCollection HandlerCollection
                                              HandlerWrapper StatisticsHandler)
@@ -817,9 +818,12 @@
         (normalized-uri-helpers/handler-maybe-wrapped-with-normalized-uri
          (ring-handler handler)
          normalize-request-uri?)
+        sess-handler (doto (SessionHandler.)
+                       (.setHandler handler))
         path (if (= "" path) "/" path)
-        ctxt-handler (doto (ContextHandler. path)
-                       (.setHandler handler))]
+        ctxt-handler (doto (ServletContextHandler.)
+                       (.setContextPath path)
+                       (.setSessionHandler sess-handler))]
     (add-handler webserver-context ctxt-handler enable-trailing-slash-redirect?)))
 
 (schema/defn ^:always-validate


### PR DESCRIPTION
Changes the ring handler to be a ServletContextHandler to address the WARN below:

```
2023-07-06 14:17:11,754 DEBUG [o.e.j.s.h.ContextHandler] scope null||/hello-proxy/world @ o.e.j.s.h.ContextHandler@54b76e47{/hello-proxy,null,AVAILABLE}
2023-07-06 14:17:11,755 DEBUG [o.e.j.s.h.ContextHandler] context=/hello-proxy||/world @ o.e.j.s.h.ContextHandler@54b76e47{/hello-proxy,null,AVAILABLE}
2023-07-06 14:17:11,755 WARN  [o.e.j.s.h.ContextHandler] Unimplemented getRequestCharacterEncoding() - use org.eclipse.jetty.servlet.ServletContextHandler
```

Observed in the ring-middleware tests, also observed in another repo I lost track of. Using setHandler in this case also generates a warning that it should not be called directly, setting a SessionHandler or using insertHandler appears to be the way Jetty wants it now.