### PR TITLE
(PE-35509) Add ClosureLatchSyncer interface to sync client and server closures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+Updated to Jetty 10.0.18, added ClosureLatchSyncer interface Jetty WebSocketAdapter object to sync closure of websocket client and server.
+
 ## 1.0.1
 
 Added ExecutionException handling when shutting down the server. Corrected WebSocketProtocol idle-timeout! function to produce a Duration.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def jetty-version "10.0.15")
+(def jetty-version "10.0.18")
 
 (defproject com.puppetlabs/trapperkeeper-webserver-jetty10 "1.0.2-SNAPSHOT"
   :description "A jetty10-based webserver implementation for use with the puppetlabs/trapperkeeper service framework."

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty10_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty10_core.clj
@@ -681,7 +681,7 @@
                                (.getStopTimeout server))))
       ;; This exception handling was added since we currently manually stop handlers within pcp-broker
       ;; for debugging purposes there - on shutdown if Jetty 10 sees a STOPPED handler it throws an
-      ;; ExecutionException with a IllegalStateExeception as it's cause and if unhandled shutdown
+      ;; ExecutionException with a IllegalStateException as it's cause and if unhandled shutdown
       ;; stops and the server goes into a FAILED state
       (catch ExecutionException e
         (log/error (.getCause e) (i18n/trs "Web server failed to shut down gracefully due to ExecutionException with inner exception of type {0}; cancelling remaining requests."


### PR DESCRIPTION
Updates Jetty to 10.0.18 and adds the ClosureLatchSyncer interface to the Jetty WebSocketAdapter object to sync closure of websocket client and server. This was a mechanism observed in the code examples Jetty provides (https://github.com/jetty-project/embedded-jetty-websocket-examples/blob/10.0.x/native-jetty-websocket-example/src/main/java/org/eclipse/jetty/demo/EventEndpoint.java) which may just be the most authoritative document they provide on good implementation practices.