### PR TITLE
(PE-35511) add Response in ring-handler handler request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## unreleased changes
 
+## 1.0.5
+* add the  [`Response`](https://www.eclipse.org/jetty/javadoc/jetty-10/org/eclipse/jetty/server/Response.html) under the `:response` key in the request for ring-handlers.
+
 ## 1.0.4
 * Added additional trace level logging to help diagnose issues
 * Removed some use of reflection by applying type metadata tags

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ Then your routes will be served at `/my-app/foo` and `my-app/bar`.
 You may specify `""` as the value for `path` if you are only registering a single
 handler and do not need to prefix the URL.
 
+In the handler, in the request passed to it, under the `:response` key is the
+[`Response`](https://www.eclipse.org/jetty/javadoc/jetty-10/org/eclipse/jetty/server/Response.html) that is used
+to deliver the response from the server.
+
 There is also a three argument version of this function which takes these arguments:
 `[handler path options]`. `options` is a map containing three optional keys.
 

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty10_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty10_core.clj
@@ -521,7 +521,8 @@
   [handler]
   (proxy [AbstractHandler] []
     (handle [_ ^Request base-request request response]
-      (let [request-map  (servlet/build-request-map request)
+      (let [request-map  (assoc (servlet/build-request-map request)
+                           :response response)
             response-map (handler request-map)]
         (when response-map
           (servlet/update-servlet-response response response-map)


### PR DESCRIPTION
This adds the  [`Response`](https://www.eclipse.org/jetty/javadoc/jetty-10/org/eclipse/jetty/server/Response.html) in the ring-handler handler's request under the `:response` key.