### PR TITLE
(PE-37252) discontinue use of logback-access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## unreleased changes
 
+## 1.0.6
+* route logging through a SLF4J Custom logger as logback-access no longer works with jetty10. This is a work around until full featured logging is developed.
+
+
 ## 1.0.5
 * add the  [`Response`](https://www.eclipse.org/jetty/javadoc/jetty-10/org/eclipse/jetty/server/Response.html) under the `:response` key in the request for ring-handlers.
 


### PR DESCRIPTION
This disables the use of logback-access because logback-access is not compatible with Jetty 10.  See https://github.com/jetty/jetty.project/issues/5996

This changes the implementation to use a CustomRequestLog in jetty with the SLF4JLogWriter until a better solution can be determined.  This means that logging won't obey the logback-access configuration specified.