### PR TITLE
(PE-36484) Convert ring-handler to use ServletContextHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## unreleased changes
 
+## 1.0.7
+* convert ring handler to using ServletContextHandler as previously used ContextHandler no longer supports the getRequestCharacterEncoding() function.
+
 ## 1.0.6
 * route logging through a SLF4J Custom logger as logback-access no longer works with jetty10. This is a work around until full featured logging is developed.
 

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty10_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty10_core.clj
@@ -519,7 +519,7 @@
 (defn- ring-handler
   "Returns an Jetty Handler implementation for the given Ring handler."
   [handler]
-  (proxy [AbstractHandler] []
+  (proxy [HandlerWrapper] []
     (handle [_ ^Request base-request request response]
       (let [request-map  (assoc (servlet/build-request-map request)
                            :response response)
@@ -817,13 +817,13 @@
    path :- schema/Str
    enable-trailing-slash-redirect? :- schema/Bool
    normalize-request-uri? :- schema/Bool]
-  (let [handler
-        (normalized-uri-helpers/handler-maybe-wrapped-with-normalized-uri
-         (ring-handler handler)
-         normalize-request-uri?)
+  (let [handler (normalized-uri-helpers/handler-maybe-wrapped-with-normalized-uri
+                 (ring-handler handler)
+                 normalize-request-uri?)
         path (if (= "" path) "/" path)
-        ctxt-handler (doto (ContextHandler. path)
-                       (.setHandler handler))]
+        ctxt-handler (doto (ServletContextHandler. ServletContextHandler/NO_SESSIONS)
+                       (.setContextPath path)
+                       (.insertHandler handler))]
     (add-handler webserver-context ctxt-handler enable-trailing-slash-redirect?)))
 
 (schema/defn ^:always-validate


### PR DESCRIPTION
In Jetty10, ContextHandlers no longer have the same Servlet functions they did in Jetty9, ServletContextHandler must be used instead. Converts ring-handler to a ServletContextHandler to enable our fix our calls to getRequestCharacterEncoding().