### PR TITLE
(PE-35512) disable SNI checking 

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty10_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty10_core.clj
@@ -31,7 +31,7 @@
            (org.eclipse.jetty.proxy ProxyServlet)
            (org.eclipse.jetty.server AbstractConnectionFactory ConnectionFactory CustomRequestLog Handler HttpConfiguration
                                      HttpConnectionFactory Request
-                                     Server ServerConnector Slf4jRequestLogWriter SymlinkAllowedResourceAliasChecker)
+                                     SecureRequestCustomizer Server ServerConnector Slf4jRequestLogWriter SymlinkAllowedResourceAliasChecker)
            (org.eclipse.jetty.server.handler AbstractHandler ContextHandler
                                              ContextHandlerCollection HandlerCollection
                                              HandlerWrapper StatisticsHandler)
@@ -322,7 +322,10 @@
 
 (defn- http-configuration
   [request-header-size]
-  (let [http-config (doto (HttpConfiguration.)
+  (let [customizer (SecureRequestCustomizer. false)
+        _ (.setSniRequired customizer false)
+        http-config (doto (HttpConfiguration.)
+                      (.addCustomizer customizer)
                       (.setSendDateHeader true)
                       (.setSendServerVersion false)
                       ;; LEGACY uri compliance mode that models Jetty-9.4 behavior by allowing


### PR DESCRIPTION
This adds a customized SecureRequestCustomizer that makes `SNI` not
required, and turns off host checking for `SNI` which will allow localhost
connections to a server that doesn't have `localhost` in its cert specification.