### PR TITLE
(PE-37256) restore access-logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## unreleased changes
 
+## 1.0.12
+- Reenable logback-access logging.  This uses the "setRequestLog" function in jetty10 which guarantees that the request/response is settled prior to doing the logging.
+
 ## 1.0.11
 - Remove default character encoding added in 1.0.8; add tests demonstrating overriding content-type
 - add customized SecureRequestCustomizer that makes SNI not

--- a/java/com/puppetlabs/trapperkeeper/services/webserver/jetty10/utils/InternalSslContextFactory.java
+++ b/java/com/puppetlabs/trapperkeeper/services/webserver/jetty10/utils/InternalSslContextFactory.java
@@ -1,9 +1,9 @@
 package com.puppetlabs.trapperkeeper.services.webserver.jetty10.utils;
 
-import org.eclipse.jetty.util.log.Log;
-import org.eclipse.jetty.util.log.Logger;
 import org.eclipse.jetty.util.security.CertificateUtils;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.security.cert.CRL;
@@ -15,7 +15,7 @@ public class InternalSslContextFactory extends SslContextFactory.Server {
     private static int maxTries = 25;
     private static int sleepInMillisecondsBetweenTries = 100;
     private static final Logger LOG =
-            Log.getLogger(InternalSslContextFactory.class);
+            LoggerFactory.getLogger(InternalSslContextFactory.class);
     private static Consumer<SslContextFactory> consumer = sslContextFactory
             -> {};
 

--- a/java/com/puppetlabs/trapperkeeper/services/webserver/jetty10/utils/ModifiedJettyModernServerAdapter.java
+++ b/java/com/puppetlabs/trapperkeeper/services/webserver/jetty10/utils/ModifiedJettyModernServerAdapter.java
@@ -1,0 +1,41 @@
+package com.puppetlabs.trapperkeeper.services.webserver.jetty10.utils;
+
+import ch.qos.logback.access.jetty.JettyModernServerAdapter;
+import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ModifiedJettyModernServerAdapter extends JettyModernServerAdapter {
+    // these are package private in the JettyServerAdapter, unfortunately
+    Request request;
+    Response response;
+
+    public ModifiedJettyModernServerAdapter(Request jettyRequest, Response jettyResponse) {
+        super(jettyRequest, jettyResponse);
+        this.response = jettyResponse;
+        this.request = jettyRequest;
+    }
+
+    /**
+     * buildResponseMap
+     * This is a replacement of the buildResponseLog in JettyModernServerAdapter to
+     * make it compatible with Jetty 10 responses. The provided version of logback-acccess
+     * has a different signature expectation for "getHttpFields" which causes runtime failures.
+     * @return a map of the headers.
+     */
+    @Override
+    public Map<String, String> buildResponseHeaderMap() {
+        Map<String, String> responseHeaderMap = new HashMap<String,String>();
+
+        for (HttpField httpField : this.response.getHttpFields()) {
+            String key = httpField.getName();
+            String value = httpField.getValue();
+            responseHeaderMap.put(key, value);
+        }
+
+        return responseHeaderMap;
+    }
+}

--- a/java/com/puppetlabs/trapperkeeper/services/webserver/jetty10/utils/ModifiedRequestLogImpl.java
+++ b/java/com/puppetlabs/trapperkeeper/services/webserver/jetty10/utils/ModifiedRequestLogImpl.java
@@ -1,0 +1,87 @@
+package com.puppetlabs.trapperkeeper.services.webserver.jetty10.utils;
+
+import ch.qos.logback.access.jetty.JettyServerAdapter;
+import ch.qos.logback.access.jetty.RequestLogImpl;
+import ch.qos.logback.access.spi.AccessEvent;
+import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.spi.AppenderAttachableImpl;
+import ch.qos.logback.core.spi.FilterReply;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+
+import java.util.Iterator;
+
+/**
+ * Provide an alternative RequestLogImpl implementation that is compatible with Jetty 10
+ */
+public class ModifiedRequestLogImpl extends RequestLogImpl {
+    // unfortunately, this field is private in RequestLogImpl, so we provide our own version of it, and recreate
+    // all the functions in the RequestLogImpl that use it
+    AppenderAttachableImpl<IAccessEvent> aai = new AppenderAttachableImpl<IAccessEvent>();
+
+    /**
+     * log - override the log funciton in RequestLogImpl for the sole purpose of changing the type of the `makeJettyServerAdapter`
+     *       to make it compatible with jetty10.
+     * @param jettyRequest
+     * @param jettyResponse
+     */
+    @Override
+    public void log(Request jettyRequest, Response jettyResponse) {
+        JettyServerAdapter adapter = this.makeJettyServerAdapter(jettyRequest, jettyResponse);
+        IAccessEvent accessEvent = new AccessEvent(this, jettyRequest, jettyResponse, adapter);
+        if (this.getFilterChainDecision((IAccessEvent)accessEvent) != FilterReply.DENY) {
+            this.aai.appendLoopOnAppenders(accessEvent);
+        }
+    }
+
+    /**
+     * Provide a new JettyServerAdapter that is compatible with Jetty 10.
+     * @param jettyRequest
+     * @param jettyResponse
+     * @return
+     */
+    private JettyServerAdapter makeJettyServerAdapter(Request jettyRequest, Response jettyResponse) {
+        return new ModifiedJettyModernServerAdapter(jettyRequest, jettyResponse);
+    }
+
+    @Override
+    public void stop() {
+        this.aai.detachAndStopAllAppenders();
+        super.stop();
+    }
+    @Override
+    public void addAppender(Appender<IAccessEvent> newAppender) {
+        aai.addAppender(newAppender);
+    }
+
+    @Override
+    public Iterator<Appender<IAccessEvent>> iteratorForAppenders() {
+        return aai.iteratorForAppenders();
+    }
+
+    @Override
+    public Appender<IAccessEvent> getAppender(String name) {
+        return aai.getAppender(name);
+    }
+
+    @Override
+    public boolean isAttached(Appender<IAccessEvent> appender) {
+        return aai.isAttached(appender);
+    }
+
+    @Override
+    public void detachAndStopAllAppenders() {
+        aai.detachAndStopAllAppenders();
+    }
+
+    @Override
+    public boolean detachAppender(Appender<IAccessEvent> appender) {
+        return aai.detachAppender(appender);
+    }
+
+    @Override
+    public boolean detachAppender(String name) {
+        return aai.detachAppender(name);
+    }
+}

--- a/project.clj
+++ b/project.clj
@@ -35,6 +35,9 @@
                  [prismatic/schema]
                  [ring/ring-servlet]
                  [ring/ring-codec]
+                 [ch.qos.logback/logback-access]
+                 [ch.qos.logback/logback-core]
+                 [ch.qos.logback/logback-classic]
 
                  [puppetlabs/ssl-utils]
                  [puppetlabs/kitchensink]
@@ -79,9 +82,6 @@
                                           [org.clojure/tools.namespace]
                                           [compojure]
                                           [ring/ring-core]
-                                          [ch.qos.logback/logback-classic]
-                                          [ch.qos.logback/logback-core]
-                                          [ch.qos.logback/logback-access]
                                           [hato "0.9.0"]]}]
              :dev [:defaults
                    :pseudo-dev

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty10_service_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty10_service_test.clj
@@ -720,42 +720,42 @@
 
 
 ;; PE-37252 temporarily disable logging tests
-;(deftest request-logging-test
-;  (with-app-with-config
-;   app
-;   [jetty10-service hello-webservice]
-;   {:webserver {:port 8080
-;                ;; Restrict the number of threads available to the webserver
-;                ;; so we can easily test whether thread-local values in the
-;                ;; MDC are cleaned up.
-;                :acceptor-threads 1
-;                :selector-threads 1 ; You actually end up with 2 threads.
-;                :max-threads 4
-;                :access-log-config "./dev-resources/puppetlabs/trapperkeeper/services/webserver/request-logging.xml"}}
-;
-;   (testing "request logging occurs when :access-log-config is configured"
-;      (with-test-access-logging
-;        (http-get "http://localhost:8080/hi_world/")
-;       ; Logging is done in a separate thread from Jetty and this test. As a result,
-;       ; we have to sleep the thread to avoid a race condition.
-;       (Thread/sleep 10)
-;       (let [list (TestListAppender/list)]
-;         (is (re-find #"\"GET /hi_world/ HTTP/1.1\" 200" (first list))))))
-;
-;   (testing "Mapped Diagnostic Context values are available to the access logger"
-;      (with-test-access-logging
-;        (http-put "http://localhost:8080/mdc?mdc_key=mdc-test" {:body "hello"})
-;        (Thread/sleep 10)
-;        (let [list (TestListAppender/list)]
-;          (is (str/ends-with? (first list) "hello\n")))))
-;
-;   (testing "Mapped Diagnostic Context values are cleared after each request"
-;      (http-put "http://localhost:8080/mdc?mdc_key=mdc-persist" {:body "foo"})
-;
-;      ;; Loop to ensure we hit all threads.
-;      (let [responses (for [n (range 0 10)]
-;                        (http-get "http://localhost:8080/mdc?mdc_key=mdc-persist"))]
-;        (is (every? #(not= "foo" %) (map :body responses)))))))
+(deftest request-logging-test
+  (with-app-with-config
+   app
+   [jetty10-service hello-webservice]
+   {:webserver {:port 8080
+                ;; Restrict the number of threads available to the webserver
+                ;; so we can easily test whether thread-local values in the
+                ;; MDC are cleaned up.
+                :acceptor-threads 1
+                :selector-threads 1 ; You actually end up with 2 threads.
+                :max-threads 4
+                :access-log-config "./dev-resources/puppetlabs/trapperkeeper/services/webserver/request-logging.xml"}}
+
+   (testing "request logging occurs when :access-log-config is configured"
+      (with-test-access-logging
+        (http-get "http://localhost:8080/hi_world/")
+       ; Logging is done in a separate thread from Jetty and this test. As a result,
+       ; we have to sleep the thread to avoid a race condition.
+       (Thread/sleep 10)
+       (let [list (TestListAppender/list)]
+         (is (re-find #"\"GET /hi_world/ HTTP/1.1\" 200" (first list))))))
+
+   (testing "Mapped Diagnostic Context values are available to the access logger"
+      (with-test-access-logging
+        (http-put "http://localhost:8080/mdc?mdc_key=mdc-test" {:body "hello"})
+        (Thread/sleep 10)
+        (let [list (TestListAppender/list)]
+          (is (str/ends-with? (first list) "hello\n")))))
+
+   (testing "Mapped Diagnostic Context values are cleared after each request"
+      (http-put "http://localhost:8080/mdc?mdc_key=mdc-persist" {:body "foo"})
+
+      ;; Loop to ensure we hit all threads.
+      (let [responses (for [n (range 0 10)]
+                        (http-get "http://localhost:8080/mdc?mdc_key=mdc-persist"))]
+        (is (every? #(not= "foo" %) (map :body responses)))))))
 
 (deftest graceful-shutdown-test
   (testing "jetty10 webservers shut down gracefully by default"


### PR DESCRIPTION
Previously access-logging was switched to the Jetty CustomLogger, which wrote to the main system logs by default, and didn't provide any MDC logging.

This changes the behavior to reenable access-logging by using the logback `RequestLogImpl` directly in the Jetty Servers `requestLog` setting.  This bypasses the previous issues with the data being settled, and allows the configuration and MDC logging to work correctly.