### PR TITLE
(maint) make logging safer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## unreleased changes
+- ensure that absent log-access-configuration files don't prevent application from functioning correctly
 
 ## 1.0.12
 - Reenable logback-access logging.  This uses the "setRequestLog" function in jetty10 which guarantees that the request/response is settled prior to doing the logging.


### PR DESCRIPTION
If the access-log provided doesn't exist, logging would throw exceptions during the operation. This adds a safety check to ensure that the file exists prior to configuring the accees logs.  Logging was added to help identify the behaviors.