### PR TITLE
(PE-37310) prevent null dereference, turn on logback logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## unreleased changes
+## 1.0.14
+- ensure null `requestLog` in the MDCRequestHandler does not cause a null dereference.
+- enable logging for access log configuration
+
+## 1.0.13
 - ensure that absent log-access-configuration files don't prevent application from functioning correctly
 
 ## 1.0.12

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty10_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty10_config.clj
@@ -487,7 +487,7 @@
           (.putObject logger CoreConstants/PATTERN_RULE_REGISTRY pattern-rules)
           (log/info (i18n/trs "Enabling access logger using file {0}" filename))
           (.setFileName logger filename)
-          (.setQuiet logger true)
+          (.setQuiet logger false)
           logger))
       (log/info (i18n/trs "Access logging file not found at {0}" filename)))))
 


### PR DESCRIPTION
This modifies the MDCRequestLogHandler to prevent setting a request logger when one isn't present.  Additionally it updates the logback startup logging for access logging setup to be turned on to make it easier to understand the failures.