### PR TITLE
(PE-37251) Remove hato as a hard dependency

### DIFF
--- a/.github/workflows/lein-test.yaml
+++ b/.github/workflows/lein-test.yaml
@@ -37,5 +37,5 @@ jobs:
           zprint: latest                # zprint
       - name: Run lein tests with dev test profile
         run: lein with-profile dev test
-      - name: Run lein tests with pseudo-dev, fips profiles
-        run: lein with-profile pseudo-dev,fips test
+      - name: Run lein tests with fips profile
+        run: lein with-profile fips test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## unreleased changes
+
+## 1.0.15
+- cleans up accidental hard dependency on hato library in project.clj, hato is now only a dev dependency.
+
 ## 1.0.14
 - ensure null `requestLog` in the MDCRequestHandler does not cause a null dereference.
 - enable logging for access log configuration

--- a/project.clj
+++ b/project.clj
@@ -66,50 +66,57 @@
 
   :test-paths ["test/clj"]
 
-  :profiles {:defaults {:source-paths ["examples/multiserver_app/src"
-                                       "examples/ring_app/src"
-                                       "examples/servlet_app/src/clj"
-                                       "examples/war_app/src"
-                                       "examples/webrouting_app/src"]
-                        :java-source-paths ["examples/servlet_app/src/java"
-                                            "test/java"]
-                        :resource-paths ["dev-resources"]
-                        :jvm-opts ["-Djava.util.logging.config.file=dev-resources/logging.properties"]}
-             :pseudo-dev [:defaults
-                          {:dependencies [[puppetlabs/http-client]
-                                          [puppetlabs/kitchensink nil :classifier "test"]
-                                          [puppetlabs/trapperkeeper nil :classifier "test"]
-                                          [org.clojure/tools.namespace]
-                                          [compojure]
-                                          [ring/ring-core]
-                                          [hato "0.9.0"]]}]
-             :dev [:defaults
-                   :pseudo-dev
-                   {:dependencies [[org.bouncycastle/bcpkix-jdk18on]
-                                   [hato "0.9.0"]]}]
+  :profiles {:dev {:source-paths ["examples/multiserver_app/src"
+                                   "examples/ring_app/src"
+                                   "examples/servlet_app/src/clj"
+                                   "examples/war_app/src"
+                                   "examples/webrouting_app/src"]
+                   :java-source-paths ["examples/servlet_app/src/java"
+                                       "test/java"]
+                   :resource-paths ["dev-resources"]
+                   :jvm-opts ["-Djava.util.logging.config.file=dev-resources/logging.properties"]
+                   :dependencies [[puppetlabs/http-client]
+                                  [puppetlabs/kitchensink nil :classifier "test"]
+                                  [puppetlabs/trapperkeeper nil :classifier "test"]
+                                  [org.clojure/tools.namespace]
+                                  [compojure]
+                                  [ring/ring-core]
+                                  [org.bouncycastle/bcpkix-jdk18on]
+                                  [hato "0.9.0"]]}
 
              ;; per https://github.com/technomancy/leiningen/issues/1907
              ;; the provided profile is necessary for lein jar / lein install
              :provided {:dependencies [[org.bouncycastle/bcpkix-jdk18on]]
                         :resource-paths ["dev-resources"]}
 
-             :fips {:dependencies [[org.bouncycastle/bcpkix-fips]
+             :fips {:source-paths ["examples/multiserver_app/src"
+                                   "examples/ring_app/src"
+                                   "examples/servlet_app/src/clj"
+                                   "examples/war_app/src"
+                                   "examples/webrouting_app/src"]
+                    :java-source-paths ["examples/servlet_app/src/java"
+                                        "test/java"]
+                    :resource-paths ["dev-resources"]
+                    :dependencies [[puppetlabs/http-client]
+                                   [puppetlabs/kitchensink nil :classifier "test"]
+                                   [puppetlabs/trapperkeeper nil :classifier "test"]
+                                   [org.bouncycastle/bcpkix-fips]
                                    [org.bouncycastle/bc-fips]
                                    [org.bouncycastle/bctls-fips]
                                    [hato "0.9.0"]]
-                     :exclusions [[org.bouncycastle/bcpkix-jdk18on]]
-                     ;; this only ensures that we run with the proper profiles
-                     ;; during testing. This JVM opt will be set in the puppet module
-                     ;; that sets up the JVM classpaths during installation.
-                     :jvm-opts ~(let [version (System/getProperty "java.version")
-                                      [major minor _] (clojure.string/split version #"\.")
-                                      unsupported-ex (ex-info "Unsupported major Java version. Expects 11 or 17."
-                                                       {:major major
-                                                        :minor minor})]
-                                  (condp = (java.lang.Integer/parseInt major)
-                                    11 ["-Djava.security.properties==dev-resources/jdk11-fips-security"]
-                                    17 ["-Djava.security.properties==dev-resources/jdk17-fips-security"]
-                                    (throw unsupported-ex)))}
+                    :exclusions [[org.bouncycastle/bcpkix-jdk18on]]
+                    ;; this only ensures that we run with the proper profiles
+                    ;; during testing. This JVM opt will be set in the puppet module
+                    ;; that sets up the JVM classpaths during installation.
+                    :jvm-opts ~(let [version (System/getProperty "java.version")
+                                     [major minor _] (clojure.string/split version #"\.")
+                                     unsupported-ex (ex-info "Unsupported major Java version. Expects 11 or 17."
+                                                             {:major major
+                                                              :minor minor})]
+                                 (condp = (java.lang.Integer/parseInt major)
+                                   11 ["-Djava.security.properties==dev-resources/jdk11-fips-security"]
+                                   17 ["-Djava.security.properties==dev-resources/jdk17-fips-security"]
+                                   (throw unsupported-ex)))}
 
              :testutils {:source-paths ^:replace ["test/clj"]
                          :java-source-paths ^:replace ["test/java"]}}


### PR DESCRIPTION
project.clj dependencies were convoluted by having multiple profiles referring to the defaults keyword and mixing with their own maps. Somehow this was bringing in hato as a hard dependency instead of a dev dependency.