### PR TITLE
(PE-37293) Add debug logging of configuration of server(s) at service start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## unreleased changes
 
+## 1.0.16
+- adds debug logging of Jetty server configuration before and after server(s) have been started
+
 ## 1.0.15
 - cleans up accidental hard dependency on hato library in project.clj, hato is now only a dev dependency.
 


### PR DESCRIPTION
Adds debug logging of server(s) configuration before starting and after starting. Current state looks like this:

```
lein test puppetlabs.trapperkeeper.services.webrouting.webrouting-service-test
Jetty server(s) starting with config: {:bar {:port 8080, :default-server true}, :foo {:port 9000}}
Jetty server bar started with context: [:bar {:handlers #object[org.eclipse.jetty.server.handler.ContextHandlerCollection 0x3c3c0fee "ContextHandlerCollection@3c3c0fee{STARTED}"], :state #object[clojure.lang.Atom 0x2e801a27 {:status :ready, :val {:endpoints {"/baz" [{:type :websocket}], "/foo" [{:type :ring}], "/bar" [{:type :ring}]}, :mbean-container #object[org.eclipse.jetty.jmx.MBeanContainer 0x354c47f "org.eclipse.jetty.jmx.MBeanContainer@354c47f"], :overrides-read-by-webserver true, :overrides nil, :ssl-context-server-factory nil, :ssl-context-client-factory nil}}], :server #object[org.eclipse.jetty.server.Server 0x18a6c71e "Server@18a6c71e{STARTED}[10.0.18,sto=30000]"]}]
Jetty server bar started with URI: http://localhost:8080/baz Stop timeout: 30,000 milliseconds.
Jetty server bar Server object dump:
 Server@18a6c71e{STARTED}[10.0.18,sto=30000] - STARTED
+= QueuedThreadPool[qtp1622950866]@60bc43d2{STARTED,8<=8<=200,i=3,r=-1,t=59901ms,q=0}[ReservedThreadExecutor@327e76c0{reserved=0/8,pending=0}] - STARTED
|  +- org.eclipse.jetty.util.thread.ThreadPoolBudget@24ab622
|  +~ org.eclipse.jetty.jmx.MBeanContainer@354c47f
|  += ReservedThreadExecutor@327e76c0{reserved=0/8,pending=0} - STARTED
. . . <rest of  object dump>
Jetty server foo started with context: [:foo {:handlers #object[org.eclipse.jetty.server.handler.ContextHandlerCollection 0x313faa75 "ContextHandlerCollection@313faa75{STARTED}"], :state #object[clojure.lang.Atom 0x4fe032c7 {:status :ready, :val {:endpoints {"/foo" [{:type :ring}], "/bar" [{:type :ring}]}, :mbean-container #object[org.eclipse.jetty.jmx.MBeanContainer 0x75179062 "org.eclipse.jetty.jmx.MBeanContainer@75179062"], :overrides-read-by-webserver true, :overrides nil, :ssl-context-server-factory nil, :ssl-context-client-factory nil}}], :server #object[org.eclipse.jetty.server.Server 0x62bb2df9 "Server@62bb2df9{STARTED}[10.0.18,sto=30000]"]}]
Jetty server foo started with URI: http://localhost:9000/foo Stop timeout: 30,000 milliseconds.
Jetty server foo Server object dump:
Jetty server foo Server object dump:
 Server@62bb2df9{STARTED}[10.0.18,sto=30000] - STARTED
+= QueuedThreadPool[qtp2126559844]@7ec0ba64{STARTED,8<=8<=200,i=3,r=-1,t=59966ms,q=0}[ReservedThreadExecutor@5d14b309{reserved=0/8,pending=0}] - STARTED
|  +- org.eclipse.jetty.util.thread.ThreadPoolBudget@11b4df48
|  +~ org.eclipse.jetty.jmx.MBeanContainer@75179062
|  += ReservedThreadExecutor@5d14b309{reserved=0/8,pending=0} - STARTED
|  |  +> threads size=0
|  +> threads size=8
. . . <rest of object dump>
```

Example with SSL info (not too informative):
```
Jetty server(s) starting with config: {:ssl-cert "./dev-resources/config/jetty/ssl/certs/localhost.pem", :ssl-key "./dev-resources/config/jetty/ssl/private_keys/localhost.pem", :ssl-ca-cert "./dev-resources/config/jetty/ssl/certs/ca.pem", :ssl-host "0.0.0.0", :ssl-port 9000}
Jetty server default started with context: [:default {:handlers #object[org.eclipse.jetty.server.handler.ContextHandlerCollection 0x7798af6a "ContextHandlerCollection@7798af6a{STARTED}"], :state #object[clojure.lang.Atom 0x668bafb5 {:status :ready, :val {:endpoints {}, :mbean-container #object[org.eclipse.jetty.jmx.MBeanContainer 0x62e6afd8 "org.eclipse.jetty.jmx.MBeanContainer@62e6afd8"], :overrides-read-by-webserver true, :overrides nil, :ssl-context-server-factory #object[com.puppetlabs.trapperkeeper.services.webserver.jetty10.utils.InternalSslContextFactory 0x556323d9 "InternalSslContextFactory@556323d9[provider=null,keyStore=null,trustStore=null]"], :ssl-context-client-factory #object[org.eclipse.jetty.util.ssl.SslContextFactory$Client 0x263294c5 "Client@263294c5[provider=null,keyStore=null,trustStore=null]"]}}], :server #object[org.eclipse.jetty.server.Server 0x12db00a7 "Server@12db00a7{STARTED}[10.0.18,sto=30000]"]}]
Jetty server default started with URI: https://0.0.0.0:9000/ Stop timeout: 30,000 milliseconds.
Jetty server default Server object dump:
. . .

lein test puppetlabs.trapperkeeper.services.webrouting.webrouting-service-override-settings-test
Jetty server(s) starting with config: {:port 8080}
Jetty server default started with context: [:default {:handlers #object[org.eclipse.jetty.server.handler.ContextHandlerCollection 0x2c0d1318 "ContextHandlerCollection@2c0d1318{STARTED}"], :state #object[clojure.lang.Atom 0x82edfd4 {:status :ready, :val {:endpoints {}, :mbean-container #object[org.eclipse.jetty.jmx.MBeanContainer 0x43305ac2 "org.eclipse.jetty.jmx.MBeanContainer@43305ac2"], :overrides-read-by-webserver true, :overrides {:ssl-port 9001, :ssl-host "0.0.0.0", :ssl-cert "./dev-resources/config/jetty/ssl/certs/localhost.pem", :ssl-key "./dev-resources/config/jetty/ssl/private_keys/localhost.pem", :ssl-ca-cert "./dev-resources/config/jetty/ssl/certs/ca.pem", :ssl-crl-path "./dev-resources/config/jetty/ssl/crls/crls_none_revoked.pem"}, :ssl-context-server-factory #object[com.puppetlabs.trapperkeeper.services.webserver.jetty10.utils.InternalSslContextFactory 0x7d05e546 "InternalSslContextFactory@7d05e546[provider=null,keyStore=null,trustStore=null]"], :ssl-context-client-factory #object[org.eclipse.jetty.util.ssl.SslContextFactory$Client 0x17d8adac "Client@17d8adac[provider=null,keyStore=null,trustStore=null]"]}}], :server #object[org.eclipse.jetty.server.Server 0x3221683 "Server@3221683{STARTED}[10.0.18,sto=30000]"]}]
Jetty server default started with URI: http://localhost:8080/ Stop timeout: 30,000 milliseconds.
Jetty server default Server object dump:
. . .
```

Added pprinting the context for readability, not sure if we have another function for that purpose.