### PR TITLE
(PE-37632) update jetty 10 to 10.0.20 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## unreleased changes
 
+## 1.0.17
+- update jetty 10 to 10.0.20 to eliminate some race conditions
+- update clj-parent to the latest
+
 ## 1.0.16
 - adds debug logging of Jetty server configuration before and after server(s) have been started
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def jetty-version "10.0.18")
+(def jetty-version "10.0.20")
 
 (defproject com.puppetlabs/trapperkeeper-webserver-jetty10 "1.0.17-SNAPSHOT"
   :description "A jetty10-based webserver implementation for use with the puppetlabs/trapperkeeper service framework."
@@ -8,7 +8,7 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "7.2.7"]
+  :parent-project {:coords [puppetlabs/clj-parent "7.3.4"]
                    :inherit [:managed-dependencies]}
 
   ;; Abort when version ranges or version conflicts are detected in


### PR DESCRIPTION
This updates jetty 10 to the 10.0.20 release to bring in some
websocket fixes.

It also updates the clj-parent reference to the latest.