### PR TITLE
(maint) update setup-clojure action to the latest

### DIFF
--- a/.github/workflows/lein-test.yaml
+++ b/.github/workflows/lein-test.yaml
@@ -26,7 +26,7 @@ jobs:
           distribution: temurin
           java-version: ${{ matrix.java }}
       - name: Install Clojure tools
-        uses: DeLaGuardo/setup-clojure@10.2
+        uses: DeLaGuardo/setup-clojure@12.4
         with:
           cli: latest              # Clojure CLI based on tools.deps
           lein: latest                  # Leiningen


### PR DESCRIPTION
The cljstyle url has changed, and broke everything. This updates to a new version of the setup-clojure action that uses the right url.